### PR TITLE
Support for Int. Numbers extensions & qued cookies reponses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "j42/laravel-twilio",
+    "name": "elijan/laravel-twilio",
     "description": "A Twilio port for Laravel (4.2+)",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,10 @@
     },
     "autoload": {
         "classmap": [
-            "src/elijan",
             "src/controllers"
         ],
         "psr-0": {
-            "J42\\LaravelTwilio": "src/elijan"
+            "J42\\LaravelTwilio": "src"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "autoload": {
         "classmap": [
-            "src/j42",
+            "src/elijan",
             "src/controllers"
         ],
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     },
     "autoload": {
         "classmap": [
-            "src/j42",
+            "src/elijan",
             "src/controllers"
         ],
         "psr-0": {
-            "J42\\LaravelTwilio": "src/j42"
+            "J42\\LaravelTwilio": "src/elijan"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,17 @@
 {
     "name": "elijan/laravel-twilio",
-    "description": "A Twilio port for Laravel (4.2+)",
+    "description": "A Twilio port for Laravel (4.2+) modifed by Elijan",
     "minimum-stability": "dev",
     "authors": [
         {
             "name": "Julian Aceves",
             "email": "j@j42.me",
             "homepage": "https://j42.me"
+        },
+        {
+            "name": "Elijan Sejic",
+            "email": "elijans@gmail.com",
+            "homepage": "http://metam.co"
         }
     ],
     "repositories": [
@@ -25,7 +30,7 @@
             "src/controllers"
         ],
         "psr-0": {
-            "J42\\LaravelTwilio":  "src/j42"
+            "Elijan\\LaravelTwilio":  "src/elijan"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,11 @@
     },
     "autoload": {
         "classmap": [
+            "src/j42",
             "src/controllers"
         ],
         "psr-0": {
-            "J42\\LaravelTwilio": "src"
+            "J42\\LaravelTwilio":  "src/j42"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "elijan/laravel-twilio",
     "description": "A Twilio port for Laravel (4.2+)",
+    "minimum-stability": "dev",
     "authors": [
         {
             "name": "Julian Aceves",

--- a/readme.md
+++ b/readme.md
@@ -19,11 +19,11 @@ Add the package to your `composer.json` and run composer update:
 Then add the service providers and facades to `config/app.php`
 
 ```php
-	'J42\LaravelTwilio\LaravelTwilioServiceProvider',
+	'Elijan\LaravelTwilio\LaravelTwilioServiceProvider',
 ```
 ...
 ```php
-	'Twilio'		  => 'J42\LaravelTwilio\LaravelTwilioFacade'
+	'Twilio'		  => 'Elijan\LaravelTwilio\LaravelTwilioFacade'
 ```
 
 
@@ -144,10 +144,10 @@ Sometimes you may need to handle additional logic in a controller of your own.  
 	]);
 ```
 
-**Create your controller, extending `J42\LaravelTwilio\TwilioVerify`**
+**Create your controller, extending `Elijan\LaravelTwilio\TwilioVerify`**
 
 ```php
-	use J42\LaravelTwilio\TwilioVerify;
+	use Elijan\LaravelTwilio\TwilioVerify;
 
 	class TwilioController extends TwilioVerify {
 

--- a/src/controllers/verify/TwilioVerify.php
+++ b/src/controllers/verify/TwilioVerify.php
@@ -21,7 +21,7 @@ class TwilioVerify extends \BaseController implements TwilioVerifyInterface {
 
 		// Else New Request
 		$method = Input::get('method');
-		$phone  = preg_replace('/[^\d]+/', '', Input::get('phone'));
+        $phone  = preg_replace('/[^0^\+][^\d]+/', '', Input::get('phone'));
 		if (!Input::has('phone') || strlen($phone) < 10) return $this->respond('Please supply a valid phone number.', 500);
 
 		// Create Token
@@ -100,7 +100,7 @@ class TwilioVerify extends \BaseController implements TwilioVerifyInterface {
 		return $this->respond([
 			'phone'		=> $phone,
 			'status'	=> (isset($responses[$phone])) ? $responses[$phone]->status : null
-		], 200)->withCookie($token['cookie']);
+		], 200);
 	}
 
 	// Send Call
@@ -122,7 +122,7 @@ class TwilioVerify extends \BaseController implements TwilioVerifyInterface {
 		return $this->respond([
 			'phone'		=> $phone,
 			'status'	=> (isset($responses[$phone])) ? $responses[$phone]->status : null
-		], 200)->withCookie($token['cookie']);
+		], 200);
 
 	}
 
@@ -140,8 +140,9 @@ class TwilioVerify extends \BaseController implements TwilioVerifyInterface {
 				'valid'	=> false
 		   ]
 		];
-		$cookie['cookie'] = Cookie::make('twilio::phone', $cookie['phone'], 2);
-		return $cookie;
+        Cookie::queue('twilio::phone', $cookie['phone'], 2);
+
+        return $cookie;
 	}
 
 	// Validate Token (TTL 5m)
@@ -166,7 +167,8 @@ class TwilioVerify extends \BaseController implements TwilioVerifyInterface {
 			\Event::fire('user.phoneVerified', $payload);
 
 			// Respond w/ Object for a 5 Minute TTL
-			return $this->respond($payload, 200)->withCookie(Cookie::make('twilio::phone', $payload, 5));
+            Cookie::queue('twilio::phone', $payload, 5);
+			return $this->respond($payload, 200);
 
 		} else return false;
 	}

--- a/src/controllers/verify/TwilioVerify.php
+++ b/src/controllers/verify/TwilioVerify.php
@@ -37,7 +37,8 @@ class TwilioVerify extends \BaseController implements TwilioVerifyInterface {
 
         // Else New Request
         $method = Input::get('method');
-        $phone  = preg_replace('/[^0^\+][^\d]+/', '', Input::get('phone'));
+        $phone  = preg_replace('/\s+/', '', Input::get('phone'));
+        $phone  = preg_replace('/[^0^\+][^\d]+/', '', $phone);
         if (!Input::has('phone') || strlen($phone) < 12) return $this->respond(['message'=>'Please supply a valid phone number.'], 500);
 
         // Create Token

--- a/src/controllers/verify/TwilioVerify.php
+++ b/src/controllers/verify/TwilioVerify.php
@@ -14,7 +14,11 @@ class TwilioVerify extends \BaseController implements TwilioVerifyInterface {
 
     public function sms() {
 
-        $phone  = preg_replace('/[^0^\+][^\d]+/', '', Input::get('phone'));
+        $phone = preg_replace('/ /', Input::get('phone'));
+
+        $phone  = preg_replace('/[^0^\+][^\d]+/','',$phone);
+
+        \Log::info ("Sending SMS to".$phone);
 
         if (strlen($phone) < 12) return $this->respond(['message'=>'Please supply a valid phone number.'], 500);
 
@@ -124,7 +128,8 @@ class TwilioVerify extends \BaseController implements TwilioVerifyInterface {
             // Respond w/ 2 Minute TTL
             return $this->respond([
                 'phone'		=> $phone,
-                'status'	=> (isset($responses[$phone])) ? $responses[$phone]->status : null
+                'status'	=> (isset($responses[$phone])) ? $responses[$phone]->status : null,
+                'message'   =>$responses['message']
             ], 200);
         }
 

--- a/src/controllers/verify/TwilioVerify.php
+++ b/src/controllers/verify/TwilioVerify.php
@@ -14,7 +14,7 @@ class TwilioVerify extends \BaseController implements TwilioVerifyInterface {
 
     public function sms() {
 
-        $phone = preg_replace('/ /', Input::get('phone'));
+        $phone = preg_replace('/ /', '', Input::get('phone'));
 
         $phone  = preg_replace('/[^0^\+][^\d]+/','',$phone);
 

--- a/src/controllers/verify/TwilioVerify.php
+++ b/src/controllers/verify/TwilioVerify.php
@@ -136,7 +136,7 @@ class TwilioVerify extends \BaseController implements TwilioVerifyInterface {
     // Args: (string) $phone
     protected function createToken($phone) {
         // Generate a Random Token w 2 Minute TTL
-        $token  = ceil(mt_rand(10000,99999));
+        $token  = ceil(mt_rand(10000,999999));
         $cookie = [
             'token'		=> $token,
             'phone'		=> [

--- a/src/controllers/verify/TwilioVerify.php
+++ b/src/controllers/verify/TwilioVerify.php
@@ -12,6 +12,17 @@ class TwilioVerify extends \BaseController implements TwilioVerifyInterface {
     # Properties
     public $phone;
 
+    public function sms() {
+
+        $phone  = preg_replace('/[^0^\+][^\d]+/', '', Input::get('phone'));
+
+        if (strlen($phone) < 12) return $this->respond(['message'=>'Please supply a valid phone number.'], 500);
+
+        $token = $this->createToken($phone);
+
+        return $this->sendSms($phone, $token, Input::get('message') );
+
+    }
 
     // Main Router
     public function verify($message = null) {

--- a/src/controllers/verify/TwilioVerify.php
+++ b/src/controllers/verify/TwilioVerify.php
@@ -129,7 +129,7 @@ class TwilioVerify extends \BaseController implements TwilioVerifyInterface {
             return $this->respond([
                 'phone'		=> $phone,
                 'status'	=> (isset($responses[$phone])) ? $responses[$phone]->status : null,
-                'message'   =>$responses['message']
+                'message'   => (isset($responses['message']))?$responses['message']:'success'
             ], 200);
         }
 

--- a/src/controllers/verify/TwilioVerify.php
+++ b/src/controllers/verify/TwilioVerify.php
@@ -1,4 +1,4 @@
-<?php namespace J42\LaravelTwilio;
+<?php namespace Elijan\LaravelTwilio;
 
 use Illuminate;
 use Illuminate\Support\Facades\Config;

--- a/src/controllers/verify/TwilioVerify.php
+++ b/src/controllers/verify/TwilioVerify.php
@@ -9,176 +9,185 @@ use Illuminate\Support\Facades\Cookie;
 
 class TwilioVerify extends \BaseController implements TwilioVerifyInterface {
 
-	# Properties
-	public $phone;
+    # Properties
+    public $phone;
 
 
-	// Main Router
-	public function verify($message = null) {
+    // Main Router
+    public function verify($message = null) {
 
-		// Verify Existing?
-		if ((Cookie::has('twilio::phone')) && $this->verified()) return $this->verified();
+        // Verify Existing?
 
-		// Else New Request
-		$method = Input::get('method');
+
+        if ((Cookie::has('twilio::phone')) && $this->verified()) {
+
+            return $this->verified();
+        }
+
+        // Else New Request
+        $method = Input::get('method');
         $phone  = preg_replace('/[^0^\+][^\d]+/', '', Input::get('phone'));
-		if (!Input::has('phone') || strlen($phone) < 10) return $this->respond('Please supply a valid phone number.', 500);
+        if (!Input::has('phone') || strlen($phone) < 10) return $this->respond('Please supply a valid phone number.', 500);
 
-		// Create Token
-		$token = $this->createToken($phone);
+        // Create Token
+        $token = $this->createToken($phone);
 
-		// Populate Message
-		$message = (is_string($message)) ? str_ireplace('{code}', $token['token'], $message) : null;
+        // Populate Message
+        $message = (is_string($message)) ? str_ireplace('{code}', $token['token'], $message) : null;
 
-		// Method Responder
-		switch (strtolower($method)) {
+        // Method Responder
+        switch (strtolower($method)) {
 
-			case 'sms':
-				return $this->sendSms($phone, $token, $message);
-				break;
+            case 'sms':
+                return $this->sendSms($phone, $token, $message);
+                break;
 
-			case 'call':
-				return $this->sendCall($phone, $token);
-				break;
+            case 'call':
+                return $this->sendCall($phone, $token);
+                break;
 
-			default:
-				return $this->respond('Please choose a valid verification method.', 500);
-				break;
+            default:
+                return $this->respond('Please choose a valid verification method.', 500);
+                break;
 
-		}
+        }
 
-		// Return Default Error
-		return $this->respond('Malformed request.', 500);
+        // Return Default Error
+        return $this->respond('Malformed request.', 500);
 
-	}
-
-
-	// Twiml
-	public function twiml() {
-		if (Input::has('code')) {
-			$response = new \Services_Twilio_Twiml();
-			$response->say('Please enter the following code '.(Config::get('app.domain') ? ' on '.$this->getDomain() : '').'.');
-			$response->say(implode(', ', str_split(Input::get('code'))));
-			$response->say('Once again, your code is: ');
-			$response->say(implode(', ', str_split(Input::get('code'))));
-			print $response;
-		} else return false;
-	}
+    }
 
 
-	// Response Handler
-	// Returns: (json) JSEND-compliant response {success: ..., data: ...}
-	// Args: (mixed) $data, (int) status code
-	protected function respond($data, $code = 200) {
+    // Twiml
+    public function twiml() {
+        if (Input::has('code')) {
+            $response = new \Services_Twilio_Twiml();
+            $response->say('Please enter the following code '.(Config::get('app.domain') ? ' on '.$this->getDomain() : '').'.');
+            $response->say(implode(', ', str_split(Input::get('code'))));
+            $response->say('Once again, your code is: ');
+            $response->say(implode(', ', str_split(Input::get('code'))));
+            print $response;
+        } else return false;
+    }
 
-		switch ($code) {
-			case 200: $status = 'success'; break;
-			case 500: $status = 'error'; break;
-		}
 
-		return Response::json(compact('status', 'data'));
+    // Response Handler
+    // Returns: (json) JSEND-compliant response {success: ..., data: ...}
+    // Args: (mixed) $data, (int) status code
+    protected function respond($data, $code = 200) {
 
-	}
+        switch ($code) {
+            case 200: $status = 'success'; break;
+            case 500: $status = 'error'; break;
+        }
 
-	// Send SMS
-	// Returns: (json) JSEND-compliant response {success: ..., data: ...}
-	// Args: (string) $phone, (Array) $token
-	protected function sendSms($phone, Array $token, $message = null) {
+        return Response::json(compact('status', 'data'));
 
-		// Response(s) Indexed by Recipient Phone #(s)
-		$responses = \Twilio::sms([
-			'to'		=> $phone,
-			'message'	=> (is_string($message)) ? $message : $token['token']."\n\nPlease enter this code".(Config::get('app.domain') ? ' on '.$this->getDomain() : '')." to complete the verification process."
-		]);
+    }
 
-		// Update Model
-		if ($responses[$phone]->status === 'queued') {
-			$this->phone = Cookie::get('twilio::phone');
-		}
+    // Send SMS
+    // Returns: (json) JSEND-compliant response {success: ..., data: ...}
+    // Args: (string) $phone, (Array) $token
+    protected function sendSms($phone, Array $token, $message = null) {
 
-		// Respond w/ 2 Minute TTL
-		return $this->respond([
-			'phone'		=> $phone,
-			'status'	=> (isset($responses[$phone])) ? $responses[$phone]->status : null
-		], 200);
-	}
+        // Response(s) Indexed by Recipient Phone #(s)
+        $responses = \Twilio::sms([
+            'to'		=> $phone,
+            'message'	=> (is_string($message)) ? $message : $token['token']."\n\nPlease enter this code".(Config::get('app.domain') ? ' on '.$this->getDomain() : '')." to complete the verification process."
+        ]);
 
-	// Send Call
-	// Returns: (json) JSEND-compliant response {success: ..., data: ...}
-	// Args: (string) $phone, (Array) $token
-	protected function sendCall($phone, Array $token) {
+        // Update Model
+        if ($responses[$phone]->status === 'queued') {
+            $this->phone = Cookie::get('twilio::phone');
+        }
 
-		$responses = \Twilio::call([
-			'to'	=> $phone,
-			'twiml'	=> Config::get('laravel-twilio::twiml').'/twilio/verify/twiml?code='.$token['token']
-		]);
+        // Respond w/ 2 Minute TTL
+        return $this->respond([
+            'phone'		=> $phone,
+            'status'	=> (isset($responses[$phone])) ? $responses[$phone]->status : null
+        ], 200);
+    }
 
-		// Update Model
-		if ($responses[$phone]->status === 'queued') {
-			$this->phone = Cookie::get('twilio::phone');
-		}
+    // Send Call
+    // Returns: (json) JSEND-compliant response {success: ..., data: ...}
+    // Args: (string) $phone, (Array) $token
+    protected function sendCall($phone, Array $token) {
 
-		// Respond w/ 2 Minute TTL
-		return $this->respond([
-			'phone'		=> $phone,
-			'status'	=> (isset($responses[$phone])) ? $responses[$phone]->status : null
-		], 200);
+        $responses = \Twilio::call([
+            'to'	=> $phone,
+            'twiml'	=> Config::get('laravel-twilio::twiml').'/twilio/verify/twiml?code='.$token['token']
+        ]);
 
-	}
+        // Update Model
+        if ($responses[$phone]->status === 'queued') {
+            $this->phone = Cookie::get('twilio::phone');
+        }
 
-	// Create Token (TTL 2m)
-	// Returns: (Array) $token
-	// Args: (string) $phone
-	protected function createToken($phone) {
-		// Generate a Random Token w 2 Minute TTL
-		$token  = ceil(mt_rand(10000,99999));
-		$cookie = [
-			'token'		=> $token,
-			'phone'		=> [
-				'code'	=> $token,
-				'number'=> $phone,
-				'valid'	=> false
-		   ]
-		];
+        // Respond w/ 2 Minute TTL
+        return $this->respond([
+            'phone'		=> ['number' => $phone],
+            'status'	=> (isset($responses[$phone])) ? $responses[$phone]->status : false
+        ], 200);
+
+    }
+
+    // Create Token (TTL 2m)
+    // Returns: (Array) $token
+    // Args: (string) $phone
+    protected function createToken($phone) {
+        // Generate a Random Token w 2 Minute TTL
+        $token  = ceil(mt_rand(10000,99999));
+        $cookie = [
+            'token'		=> $token,
+            'phone'		=> [
+                'code'	=> $token,
+                'number'=> $phone,
+                'valid'	=> false
+            ]
+        ];
         Cookie::queue('twilio::phone', $cookie['phone'], 2);
 
         return $cookie;
-	}
+    }
 
-	// Validate Token (TTL 5m)
-	// Returns: (json || false) JSEND-compliant response or false (passthrough)
-	// Args: void
-	protected function verified() {
+    // Validate Token (TTL 5m)
+    // Returns: (json || false) JSEND-compliant response or false (passthrough)
+    // Args: void
+    protected function verified() {
 
-		// Valid Code || Submitted Proof?
-		$payload = Cookie::get('twilio::phone');
+        // Valid Code || Submitted Proof?
+        $payload = Cookie::get('twilio::phone');
 
-		// Valid Request
-		if ($payload['code'] == Input::get('code') ||
-			$payload['valid'] === true) {
-
-			// Validate.
-			$payload['valid'] = true;
-
-			// Update Model
-			$this->phone = $payload;
-
-			// Fire "Phone Added" Event
-			\Event::fire('user.phoneVerified', $payload);
-
-			// Respond w/ Object for a 5 Minute TTL
-            Cookie::queue('twilio::phone', $payload, 5);
-			return $this->respond($payload, 200);
-
-		} else return false;
-	}
+        // Valid Request
 
 
-	// Get Domain
-	// Returns: (string) $domain
-	// Args: void
-	private function getDomain() {
-		return ucwords(parse_url(Config::get('app.domain'), PHP_URL_HOST));
-	}
+
+        if ($payload['code'] == (float)Input::get('code') ||
+            $payload['valid'] === true) {
+
+            // Validate.
+            $payload['valid'] = true;
+
+            // Update Model
+            $this->phone = $payload;
+
+            // Fire "Phone Added" Event
+            \Event::fire('user.phoneVerified', $payload);
+
+            // Respond w/ Object for a 5 Minute TTL
+            // Cookie::queue('twilio::phone', $payload, 5);
+            $response =   $this->respond($payload, 200)->withCookie(Cookie::make('twilio::phone', $payload, 5));
+            return $response;
+
+        } else return false;
+    }
+
+
+    // Get Domain
+    // Returns: (string) $domain
+    // Args: void
+    private function getDomain() {
+        return ucwords(parse_url(Config::get('app.domain'), PHP_URL_HOST));
+    }
 
 }

--- a/src/controllers/verify/TwilioVerify.php
+++ b/src/controllers/verify/TwilioVerify.php
@@ -81,6 +81,7 @@ class TwilioVerify extends \BaseController implements TwilioVerifyInterface {
             case 500: $status = 'error'; break;
         }
 
+
         return Response::json(compact('status', 'data'));
 
     }
@@ -97,15 +98,22 @@ class TwilioVerify extends \BaseController implements TwilioVerifyInterface {
         ]);
 
         // Update Model
-        if ($responses[$phone]->status === 'queued') {
-            $this->phone = Cookie::get('twilio::phone');
+
+
+        if($responses[$phone]) {
+
+            if ($responses[$phone]->status === 'queued') {
+                $this->phone = Cookie::get('twilio::phone');
+            }
+
+            // Respond w/ 2 Minute TTL
+            return $this->respond([
+                'phone'		=> $phone,
+                'status'	=> (isset($responses[$phone])) ? $responses[$phone]->status : null
+            ], 200);
         }
 
-        // Respond w/ 2 Minute TTL
-        return $this->respond([
-            'phone'		=> $phone,
-            'status'	=> (isset($responses[$phone])) ? $responses[$phone]->status : null
-        ], 200);
+        return $this->respond($responses, 500);
     }
 
     // Send Call

--- a/src/controllers/verify/TwilioVerifyInterface.php
+++ b/src/controllers/verify/TwilioVerifyInterface.php
@@ -1,4 +1,4 @@
-<?php namespace J42\LaravelTwilio;
+<?php namespace Elijan\LaravelTwilio;
 
 interface TwilioVerifyInterface {
 

--- a/src/elijan/LaravelTwilio/LaravelTwilioFacade.php
+++ b/src/elijan/LaravelTwilio/LaravelTwilioFacade.php
@@ -1,4 +1,4 @@
-<?php namespace J42\LaravelTwilio;
+<?php namespace Elijan\LaravelTwilio;
 
 use Illuminate\Support\Facades\Facade;
 

--- a/src/elijan/LaravelTwilio/LaravelTwilioServiceProvider.php
+++ b/src/elijan/LaravelTwilio/LaravelTwilioServiceProvider.php
@@ -20,7 +20,7 @@ class LaravelTwilioServiceProvider extends ServiceProvider {
 	 * @return void
 	 */
 	public function boot() {
-		$this->package('j42/laravel-twilio');
+		$this->package('elijan/laravel-twilio');
 		include __DIR__.'/../../routes.php';
 	}
 

--- a/src/elijan/LaravelTwilio/LaravelTwilioServiceProvider.php
+++ b/src/elijan/LaravelTwilio/LaravelTwilioServiceProvider.php
@@ -1,4 +1,4 @@
-<?php namespace J42\LaravelTwilio;
+<?php namespace Elijan\LaravelTwilio;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\App;

--- a/src/elijan/LaravelTwilio/TwilioClient.php
+++ b/src/elijan/LaravelTwilio/TwilioClient.php
@@ -50,6 +50,9 @@ class TwilioClient {
         // Message Loop
         foreach ($this->to as $number) {
             // Send Via Client
+
+            \Log::info ("Sending Via Twilio Client to: ".$number. "  message: ".$options['message']);
+
             try {
                 $this->response[$number] = $this->twilio->account->messages->sendMessage($this->from, $number, $options['message']);
             } catch (\Exception $e) {

--- a/src/elijan/LaravelTwilio/TwilioClient.php
+++ b/src/elijan/LaravelTwilio/TwilioClient.php
@@ -30,8 +30,14 @@ class TwilioClient {
     public function sms(Array $options, callable $callback = null) {
 
         // Configure Message
-        if (isset($options['to'])) $this->setTo($options['to']);
-        if (isset($options['from'])) $this->setFrom($options['from']);
+        //no we don't want this
+         /*  if (isset($options['to'])) $this->setTo($options['to']);
+        if (isset($options['from'])) $this->setFrom($options['from']);*/
+
+        //single repcipient only, so we can tun it as a service
+        if (isset($options['to'])) {
+            $this->to = [$options['to']];
+        }
 
         // Configure Response Handler
         $this->response = [];

--- a/src/elijan/LaravelTwilio/TwilioClient.php
+++ b/src/elijan/LaravelTwilio/TwilioClient.php
@@ -1,4 +1,4 @@
-<?php namespace J42\LaravelTwilio;
+<?php namespace Elijan\LaravelTwilio;
 
 class TwilioClient {
 

--- a/src/j42/LaravelTwilio/TwilioClient.php
+++ b/src/j42/LaravelTwilio/TwilioClient.php
@@ -2,228 +2,231 @@
 
 class TwilioClient {
 
-	# Properties
-	protected $twilio;			// Services_Twilio (Twilio REST Client)
-	protected $from = null;		// Initiating #
-	protected $to = [];			// Recipient #s
-	protected $response = [];	// Response (by #)
+    # Properties
+    protected $twilio;			// Services_Twilio (Twilio REST Client)
+    protected $from = null;		// Initiating #
+    protected $to = [];			// Recipient #s
+    protected $response = [];	// Response (by #)
 
 
-	// Return: (obj) TwilioClient
-	// Args: (Array) $config
-	public function __construct(Array $config) {
+    // Return: (obj) TwilioClient
+    // Args: (Array) $config
+    public function __construct(Array $config) {
 
-		// Sanity Check
-		if (!is_string($config['key']) || !is_string($config['token'])) throw new \UnexpectedValueException('Please make sure valid API keys and tokens are set.');
+        // Sanity Check
+        if (!is_string($config['key']) || !is_string($config['token'])) throw new \UnexpectedValueException('Please make sure valid API keys and tokens are set.');
 
-		// Create Client
-		$this->twilio = $this->createClient($config);
+        // Create Client
+        $this->twilio = $this->createClient($config);
 
-		// Set Default From?
-		if (!empty($config['from'])) $this->setFrom($config['from']);
+        // Set Default From?
+        if (!empty($config['from'])) $this->setFrom($config['from']);
 
-	}
-
-
-	// Return: (Array) response, indexed by phone #
-	// Args: (Array) $options, (callable) $callback
-	public function sms(Array $options, callable $callback = null) {
-
-		// Configure Message
-		if (isset($options['to'])) $this->setTo($options['to']);
-		if (isset($options['from'])) $this->setFrom($options['from']);
-
-		// Configure Response Handler
-		$this->response = [];
-
-		// Sanity Checks
-		if (empty($this->to) || !is_array($this->to)) throw new \UnexpectedValueException('Please enter recipients.');
-		if (!is_string($this->from)) throw new \UnexpectedValueException('Please configure a valid "from" address.');
-		if (!is_string($options['message'])) throw new \UnexpectedValueException('Please enter a message.');
-
-		// Message Loop
-		foreach ($this->to as $number) {
-			// Send Via Client
-			try {
-				$this->response[$number] = $this->twilio->account->messages->sendMessage($this->from, $number, $options['message']);
-			} catch (\Exception $e) {
-				$this->response[$number] = false;
-				\Log::error($e->getMessage());
-			}
-		}
-
-		// Callback Attempt
-		if (is_callable($callback)) {
-			call_user_func_array($callback, [$this->response]);
-		}
-
-		return $this->response;
-
-	}
+    }
 
 
-	// Return: (Array) responses, indexed by phone #
-	// Args: (Array) $options, (callable) $callback
-	public function call(Array $options, callable $callback = null) {
+    // Return: (Array) response, indexed by phone #
+    // Args: (Array) $options, (callable) $callback
+    public function sms(Array $options, callable $callback = null) {
 
-		// Configure Message
-		if (isset($options['to'])) $this->setTo($options['to']);
-		if (isset($options['from'])) $this->setFrom($options['from']);
+        // Configure Message
+        if (isset($options['to'])) $this->setTo($options['to']);
+        if (isset($options['from'])) $this->setFrom($options['from']);
 
-		// Configure Response Handler
-		$this->response = [];
+        // Configure Response Handler
+        $this->response = [];
 
-		// Sanity Checks
-		if (empty($this->to) || !is_array($this->to)) throw new \UnexpectedValueException('Please enter recipients.');
-		if (!is_string($this->from)) throw new \UnexpectedValueException('Please configure a valid "from" address.');
-		if (!is_string($options['twiml'])) throw new \UnexpectedValueException('Please enter a valid TWIML endpoint.');
+        // Sanity Checks
+        if (empty($this->to) || !is_array($this->to)) throw new \UnexpectedValueException('Please enter recipients.');
+        if (!is_string($this->from)) throw new \UnexpectedValueException('Please configure a valid "from" address.');
+        if (!is_string($options['message'])) throw new \UnexpectedValueException('Please enter a message.');
 
-		// Message Loop
-		foreach ($this->to as $number) {
-			// Send Via Client
-			try {
-				$this->response[$number] = $this->twilio->account->calls->create($this->from, $number, $this->toAbsoluteUrl($options['twiml']));
-			} catch (\Exception $e) {
-				$this->response[$number] = false;
-				\Log::error($e->getMessage());
-			}
-		}
+        // Message Loop
+        foreach ($this->to as $number) {
+            // Send Via Client
+            try {
+                $this->response[$number] = $this->twilio->account->messages->sendMessage($this->from, $number, $options['message']);
+            } catch (\Exception $e) {
 
-		// Callback Attempt
-		if (is_callable($callback)) {
-			call_user_func_array($callback, [$this->response]);
-		}
+                $this->response['error'] = true;
+                $this->response[$number] = false;
+                $this->response['message'] = $e->getMessage();
+                \Log::error($e->getMessage());
+            }
+        }
 
-		return $this->response;
+        // Callback Attempt
+        if (is_callable($callback)) {
+            call_user_func_array($callback, [$this->response]);
+        }
 
-	}
+        return $this->response;
 
-
-	// Return: (Array) list of numbers (->phone_number)
-	// Args: (Array) $options [search options], (Array) $features [number features & config], (int) # of numbers to acquire
-	public function numbersNear(Array $options, Array $features = null, $buy = false) {
-		$features = (is_array($features)) ? $features : \Config::get('laravel-twilio::features');
-		$features = (is_array($features)) ? $features : [];
-		$found = $this->twilio->account->available_phone_numbers->getList('US', 'Local', $options + $features);
-		// Purchase {n} numbers?
-		if ($buy && $buy > 0 && is_array($found->available_phone_numbers) && !empty($found->available_phone_numbers)) {
-			$purchase = array_chunk($found->available_phone_numbers, intval($buy));
-			if (!empty($purchase)) {
-				return $this->buyNumber($purchase[0], $features);
-			} else {
-				\Log::error('No available phone numbers', [$found->available_phone_numbers]);
-			}
-		}
-		// Return available phone numbers
-		return (is_array($found->available_phone_numbers)) ? $found->available_phone_numbers : [];
-	}
+    }
 
 
-	// Return: (Array) responses, indexed by phone #
-	// Args: (Array || string) $number, (Array) $config
-	public function buyNumber($number, Array $config = null, $friendly = true) {
-		$friendly 	= ($friendly) ? 'friendly_name' : 'phone_number';
-		$number 	= (is_array($number)) ? $number : [$number];
-		$config 	= (is_array($config)) ? $config : [];
-		$responses 	= [];
-		foreach ($number as $n) {
+    // Return: (Array) responses, indexed by phone #
+    // Args: (Array) $options, (callable) $callback
+    public function call(Array $options, callable $callback = null) {
 
-			if ($n) {
-				$string = (is_string($n)) ? $n : (is_object($n) ? $n->{$friendly} : $n[0]->{$friendly});
-				try {
-					$responses[$string] = $this->twilio->account->incoming_phone_numbers->create([
-						'PhoneNumber'	=> (string) $string
-					] + $config);
-				} catch (\Exception $e) {
-					$responses[$string] = false;
-					\Log::error('Error purchasing number.', [$n]);
-				}
-			}
+        // Configure Message
+        if (isset($options['to'])) $this->setTo($options['to']);
+        if (isset($options['from'])) $this->setFrom($options['from']);
 
-		}
-		return $responses;
-	}
+        // Configure Response Handler
+        $this->response = [];
 
+        // Sanity Checks
+        if (empty($this->to) || !is_array($this->to)) throw new \UnexpectedValueException('Please enter recipients.');
+        if (!is_string($this->from)) throw new \UnexpectedValueException('Please configure a valid "from" address.');
+        if (!is_string($options['twiml'])) throw new \UnexpectedValueException('Please enter a valid TWIML endpoint.');
 
-	// Return: (Array) responses
-	// Args: (Array || string) $numbers, (Array) $config
-	public function releaseNumber($number, Array $config = null) {
-		$number 	= (is_array($number)) ? $number : [$number];
-		$config 	= (is_array($config)) ? $config : [];
-		$responses 	= [];
-		foreach ($number as $n) {
+        // Message Loop
+        foreach ($this->to as $number) {
+            // Send Via Client
+            try {
+                $this->response[$number] = $this->twilio->account->calls->create($this->from, $number, $this->toAbsoluteUrl($options['twiml']));
+            } catch (\Exception $e) {
+                $this->response[$number] = false;
+                \Log::error($e->getMessage());
+            }
+        }
 
-			if ($n) {
-				$string = (is_string($n)) ? $n : (is_object($n) ? $n->phone_number : $n[0]->phone_number);
-				try {
-					$obj = $this->twilio->account->incoming_phone_numbers->getNumber((string) $string);
-					$responses[$string] = (!empty($obj->sid)) ? $this->twilio->account->incoming_phone_numbers->delete($obj->sid) : 'failed';
-				} catch (\Exception $e) {
-					$responses[$string] = false;
-					\Log::error('Error releasing number.', [$n]);
-				}
-			}
+        // Callback Attempt
+        if (is_callable($callback)) {
+            call_user_func_array($callback, [$this->response]);
+        }
 
-		}
-		return $responses;
-	}
+        return $this->response;
 
-	// Return: (Array) numbers
-	// Args: (Array) numbers, (Array) resource configuration
-	public function update(Array $numbers, Array $config) {
-		foreach ($numbers as $n) {
-			$sid = (is_object($n) && !empty($n->sid)) ? $n->sid : false;
-			$sid = ($sid) ? $sid : (is_array($n) && !empty($n['sid']) ? $n['sid'] : false);
-			if ($sid) {
-				$Number = $this->twilio->account->incoming_phone_numbers->get($sid);
-				$Number->update($config);
-			}
-		}
-	}
+    }
 
 
-	// Return: (obj) $this
-	// Args: (Array || string) $to
-	public function setTo($to) {
-
-		// Inject
-		if (is_string($to)) {
-			$this->to[] = $to;
-		} elseif (is_array($to)) {
-			$this->to += $to;
-		}
-
-		$this->to = array_unique($this->to);
-
-		return $this;
-	}
-
-
-	// Return: (obj) $this
-	// Args: (string) $from
-	public function setFrom($from) {
-
-		// Inject
-		if (is_string($from)) {
-			$this->from = $from;
-		}
-
-		return $this;
-	}
+    // Return: (Array) list of numbers (->phone_number)
+    // Args: (Array) $options [search options], (Array) $features [number features & config], (int) # of numbers to acquire
+    public function numbersNear(Array $options, Array $features = null, $buy = false) {
+        $features = (is_array($features)) ? $features : \Config::get('laravel-twilio::features');
+        $features = (is_array($features)) ? $features : [];
+        $found = $this->twilio->account->available_phone_numbers->getList('US', 'Local', $options + $features);
+        // Purchase {n} numbers?
+        if ($buy && $buy > 0 && is_array($found->available_phone_numbers) && !empty($found->available_phone_numbers)) {
+            $purchase = array_chunk($found->available_phone_numbers, intval($buy));
+            if (!empty($purchase)) {
+                return $this->buyNumber($purchase[0], $features);
+            } else {
+                \Log::error('No available phone numbers', [$found->available_phone_numbers]);
+            }
+        }
+        // Return available phone numbers
+        return (is_array($found->available_phone_numbers)) ? $found->available_phone_numbers : [];
+    }
 
 
-	// Return: (obj) Services_Twilio [Twilio REST Client]
-	// Args: (Array) $config [key, token]
-	private function createClient(Array $config) {
-		return new \Services_Twilio($config['key'], $config['token']);
-	}
+    // Return: (Array) responses, indexed by phone #
+    // Args: (Array || string) $number, (Array) $config
+    public function buyNumber($number, Array $config = null, $friendly = true) {
+        $friendly 	= ($friendly) ? 'friendly_name' : 'phone_number';
+        $number 	= (is_array($number)) ? $number : [$number];
+        $config 	= (is_array($config)) ? $config : [];
+        $responses 	= [];
+        foreach ($number as $n) {
 
-	// Return: (string) Absolute Path URL
-	// Args: (string) URL
-	private function toAbsoluteUrl($path) {
-		$isUrl = (preg_match('/^https?\:\/\//', $path));
-		return ($isUrl) ? $path : \Config::get('laravel-twilio::twiml').ltrim($path, ' /');
-	}
+            if ($n) {
+                $string = (is_string($n)) ? $n : (is_object($n) ? $n->{$friendly} : $n[0]->{$friendly});
+                try {
+                    $responses[$string] = $this->twilio->account->incoming_phone_numbers->create([
+                            'PhoneNumber'	=> (string) $string
+                        ] + $config);
+                } catch (\Exception $e) {
+                    $responses[$string] = false;
+                    \Log::error('Error purchasing number.', [$n]);
+                }
+            }
+
+        }
+        return $responses;
+    }
+
+
+    // Return: (Array) responses
+    // Args: (Array || string) $numbers, (Array) $config
+    public function releaseNumber($number, Array $config = null) {
+        $number 	= (is_array($number)) ? $number : [$number];
+        $config 	= (is_array($config)) ? $config : [];
+        $responses 	= [];
+        foreach ($number as $n) {
+
+            if ($n) {
+                $string = (is_string($n)) ? $n : (is_object($n) ? $n->phone_number : $n[0]->phone_number);
+                try {
+                    $obj = $this->twilio->account->incoming_phone_numbers->getNumber((string) $string);
+                    $responses[$string] = (!empty($obj->sid)) ? $this->twilio->account->incoming_phone_numbers->delete($obj->sid) : 'failed';
+                } catch (\Exception $e) {
+                    $responses[$string] = false;
+                    \Log::error('Error releasing number.', [$n]);
+                }
+            }
+
+        }
+        return $responses;
+    }
+
+    // Return: (Array) numbers
+    // Args: (Array) numbers, (Array) resource configuration
+    public function update(Array $numbers, Array $config) {
+        foreach ($numbers as $n) {
+            $sid = (is_object($n) && !empty($n->sid)) ? $n->sid : false;
+            $sid = ($sid) ? $sid : (is_array($n) && !empty($n['sid']) ? $n['sid'] : false);
+            if ($sid) {
+                $Number = $this->twilio->account->incoming_phone_numbers->get($sid);
+                $Number->update($config);
+            }
+        }
+    }
+
+
+    // Return: (obj) $this
+    // Args: (Array || string) $to
+    public function setTo($to) {
+
+        // Inject
+        if (is_string($to)) {
+            $this->to[] = $to;
+        } elseif (is_array($to)) {
+            $this->to += $to;
+        }
+
+        $this->to = array_unique($this->to);
+
+        return $this;
+    }
+
+
+    // Return: (obj) $this
+    // Args: (string) $from
+    public function setFrom($from) {
+
+        // Inject
+        if (is_string($from)) {
+            $this->from = $from;
+        }
+
+        return $this;
+    }
+
+
+    // Return: (obj) Services_Twilio [Twilio REST Client]
+    // Args: (Array) $config [key, token]
+    private function createClient(Array $config) {
+        return new \Services_Twilio($config['key'], $config['token']);
+    }
+
+    // Return: (string) Absolute Path URL
+    // Args: (string) URL
+    private function toAbsoluteUrl($path) {
+        $isUrl = (preg_match('/^https?\:\/\//', $path));
+        return ($isUrl) ? $path : \Config::get('laravel-twilio::twiml').ltrim($path, ' /');
+    }
 
 
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,6 +1,9 @@
 <?php namespace J42\LaravelTwilio;
 
 # Verification Routes
+\Route::any('twilio/sms', [
+		'uses'	=> 'J42\LaravelTwilio\TwilioVerify@sms'
+]);
 
 \Route::any('twilio/verify', [
 	'uses'	=> 'J42\LaravelTwilio\TwilioVerify@verify'

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,22 +1,22 @@
-<?php namespace J42\LaravelTwilio;
+<?php namespace Elijan\LaravelTwilio;
 
 # Verification Routes
 \Route::any('twilio/sms', [
-		'uses'	=> 'J42\LaravelTwilio\TwilioVerify@sms'
+		'uses'	=> 'Elijan\LaravelTwilio\TwilioVerify@sms'
 ]);
 
 \Route::any('twilio/verify', [
-	'uses'	=> 'J42\LaravelTwilio\TwilioVerify@verify'
+	'uses'	=> 'Elijan\LaravelTwilio\TwilioVerify@verify'
 ]);
 
 \Route::any('api/twilio/verify', [
-	'uses'	=> 'J42\LaravelTwilio\TwilioVerify@verify'
+	'uses'	=> 'Elijan\LaravelTwilio\TwilioVerify@verify'
 ]);
 
 \Route::any('twilio/verify/twiml', [
-	'uses'	=> 'J42\LaravelTwilio\TwilioVerify@twiml'
+	'uses'	=> 'Elijan\LaravelTwilio\TwilioVerify@twiml'
 ]);
 
 \Route::any('api/twilio/verify/twiml', [
-	'uses'	=> 'J42\LaravelTwilio\TwilioVerify@twiml'
+	'uses'	=> 'Elijan\LaravelTwilio\TwilioVerify@twiml'
 ]);


### PR DESCRIPTION
Modified regex to add support  for the International Numbers (i.e. +63 - E.164 Formatting) See  https://www.twilio.com/help/faq/voice/how-do-i-dial-international-numbers-with-twilio

Removed cookies in responses, instead we are queuing them for last/final response  (whcih is sent to the user) as $response->withCookie() doesn't work with internal requests (cookies are not created)
